### PR TITLE
Auth path

### DIFF
--- a/api_requests.txt
+++ b/api_requests.txt
@@ -120,3 +120,30 @@ curl --location --request DELETE 'https://ece461-project2.ue.r.appspot.com/reset
 curl --location --request DELETE 'http://127.0.0.1:8080/reset' \
 --header 'X-Authorization: bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
 
+-----------
+
+AUTHENTICATE a user:
+** make sure that there is an Entity for the user under: kind  = "user"
+
+curl --location --request PUT 'https://ece461-project2.ue.r.appspot.com/authenticate' \
+--data-raw '{
+    "User": {
+        "name": "ece461defaultadminuser",
+        "isAdmin": true
+    },
+    "Secret": {
+        "password": "correcthorsebatterystaple123(!__+@**(A"
+    }
+}'
+
+**Local version
+curl --location --request PUT 'http://127.0.0.1:8080/authenticate' \
+--data-raw '{
+    "User": {
+        "name": "ece461defaultadminuser",
+        "isAdmin": true
+    },
+    "Secret": {
+        "password": "correcthorsebatterystaple123(!__+@**(A"
+    }
+}'

--- a/api_requests.txt
+++ b/api_requests.txt
@@ -23,12 +23,12 @@ curl --location --request POST 'https://ece461-project2.ue.r.appspot.com/package
 }'
 
 **Local version
-curl --location --request POST 'http://127.0.0.1:8080/package' \
+curl -i --location --request POST 'http://127.0.0.1:8080/package' \
 --header 'X-Authorization: bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c' \
 --data-raw '{
 	"metadata": {
 		"Name": "Underscore",
-		"Version": "1.0.0",
+		"Version": "1.0.1",
 		"ID": "underscore_local"
 	},
 	"data": {
@@ -64,7 +64,7 @@ curl -i --location --request PUT 'http://127.0.0.1:8080/package/underscore_local
 --data-raw '{
     "metadata": {
         "Name": "Underscore",
-        "Version": "1.0.0",
+        "Version": "1.0.1",
         "ID": "underscore_local"
     },
     "data": {
@@ -106,7 +106,7 @@ curl --location --request GET 'https://ece461-project2.ue.r.appspot.com/package/
 
 
 **Local version
-curl --location --request GET 'http://127.0.0.1:8080/package/underscore/rate' \
+curl --location --request GET 'http://127.0.0.1:8080/package/underscore_local/rate' \
 --header 'X-Authorization: bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
 
 

--- a/app_api_requests/authenticate.py
+++ b/app_api_requests/authenticate.py
@@ -2,6 +2,7 @@ from google.cloud import datastore
 
 from flask_restful import Resource
 from flask import request
+import sys
 
 import json
 from uuid import uuid4
@@ -22,7 +23,10 @@ class Authenticate(Resource):
 
             input_password = request_body['Secret']['password']
         except Exception:
-            return {"message": "Error getting values from request body."}, 401
+            response = {
+                "message": "Error getting values from request body."
+            }
+            return response, 401
 
         datastore_client = datastore.Client()
 
@@ -35,7 +39,7 @@ class Authenticate(Resource):
         # No need to generate a new auth token.
         # CHECK THE PASSWORD
         # Return the Bearer Token.
-        if len(results == 1):
+        if len(results) == 1:
             # CHECK THE PASSWORD
             key = datastore_client.key('user', input_name)
             recorded_user = datastore_client.get(key)
@@ -45,6 +49,7 @@ class Authenticate(Resource):
                 response = {
                     "message": "Incorrect password"
                 }
+
                 return response, 401
             
             # If we get here, then the password is right.

--- a/app_api_requests/authenticate.py
+++ b/app_api_requests/authenticate.py
@@ -41,7 +41,7 @@ class Authenticate(Resource):
             recorded_user = datastore_client.get(key)
             recorded_password = recorded_user["password"]
 
-            if (recorded_password != input_password)
+            if (recorded_password != input_password):
                 response = {
                     "message": "Incorrect password"
                 }
@@ -55,7 +55,7 @@ class Authenticate(Resource):
             return response, 200
 
         # User DOES NOT exist.
-        else
+        else:
             response = {
                 "message": "Invalid User. Username is not in the Datastore."
             }

--- a/app_api_requests/authenticate.py
+++ b/app_api_requests/authenticate.py
@@ -1,0 +1,90 @@
+from google.cloud import datastore
+
+from flask_restful import Resource
+from flask import request
+
+import json
+from uuid import uuid4
+
+def print_to_stdout(*a):
+    print(*a, file = sys.stdout)
+
+class Authenticate(Resource):
+    def put(self):
+        request.get_data()
+        
+        decoded_data = request.data.decode("utf-8")
+        request_body = json.loads(decoded_data)
+        
+        try:
+            input_name = request_body['User']['name']
+            input_isAdmin = request_body['User']['isAdmin']
+
+            input_password = request_body['Secret']['password']
+        except Exception:
+            return {"message": "Error getting values from request body."}, 401
+
+        datastore_client = datastore.Client()
+
+        # Check to see if the User already exists in the registry
+        query = datastore_client.query(kind='user') # LOWERCASE "user"
+        query.add_filter("name", "=", input_name)
+        results = list(query.fetch())
+
+        # User DOES exist.
+        # No need to generate a new auth token.
+        # CHECK THE PASSWORD
+        # Return the Bearer Token.
+        if len(results == 1):
+            # CHECK THE PASSWORD
+            key = datastore_client.key('user', input_name)
+            recorded_user = datastore_client.get(key)
+            recorded_password = recorded_user["password"]
+
+            if (recorded_password != input_password)
+                response = {
+                    "message": "Incorrect password"
+                }
+                return response, 401
+            
+            # If we get here, then the password is right.
+            # Return the bearer token
+            recorded_token = recorded_user["bearerToken"]
+            response =  ("bearer " + recorded_token)
+
+            return response, 200
+
+        # User DOES NOT exist.
+        else
+            response = {
+                "message": "Invalid User. Username is not in the Datastore."
+            }
+            return response, 401
+
+        # BELOW, I create a new user ... but I think it should return an error here.
+        """
+            # The kind for the new entity
+            kind = "user"
+
+            # The name/ID for the new entity
+            name = input_name # Use the "username" for the "name/ID"/Identifier of the Entity
+
+            # The Cloud Datastore key for the new entity
+            user_key = datastore_client.key(kind, name)
+
+            # Prepares the new entity
+            new_user = datastore.Entity(key=user_key)
+            new_user["name"] = input_name
+            new_user["isAdmin"] = input_isAdmin
+            new_user["password"] = input_password
+            token = uuid4() # generates a random auth bearer token
+            # print_to_stdout("Bearer Token: " + token)
+            new_user["bearerToken"] = token
+
+            # Saves the entity
+            datastore_client.put(task)
+            
+            response =  ("bearer " + token)
+            
+            return response, 200
+            """

--- a/app_api_requests/package_by_id.py
+++ b/app_api_requests/package_by_id.py
@@ -17,10 +17,9 @@ class PackageById(Resource): # also why is this a POST request
         # print_to_stdout("PUT request went through")
         request.get_data() # Get everything from the request/URL (path params)
 
-        auth_header = request.headers.get('X-Authorization')
-        token = auth_header.split()[1]
-        # print_to_stdout("auth_header: " + auth_header)
-        # print_to_stdout("token: " + token)
+        # User Authentication:
+        auth_header = request.headers.get('X-Authorization') # auth_header = "bearer [token]"
+        token = auth_header.split()[1] # token = "[token]"
         
         # If token is in the database --> valid user
         datastore_client = datastore.Client()

--- a/app_api_requests/package_by_id.py
+++ b/app_api_requests/package_by_id.py
@@ -17,19 +17,25 @@ class PackageById(Resource): # also why is this a POST request
         # print_to_stdout("PUT request went through")
         request.get_data() # Get everything from the request/URL (path params)
 
-        bearer = request.headers.get('X-Authorization')
+        auth_header = request.headers.get('X-Authorization')
         token = auth_header.split()[1]
-        print_to_stdout("auth_header: " + auth_header)
-        print_to_stdout("token: " + token)
+        # print_to_stdout("auth_header: " + auth_header)
+        # print_to_stdout("token: " + token)
         
-        if token is None: # if token is in the database --> valid user
-            return {}, 400
-        # TODO: add authorization here in the future
-        
+        # If token is in the database --> valid user
+        datastore_client = datastore.Client()
+        query = datastore_client.query(kind='user')
+        query.add_filter("bearerToken", "=", token)
+        results = list(query.fetch())
+
+        if len(results) == 0: # The token is NOT in the database --> Invalid user
+            response = {
+                'message': "Unauthorized user. Bearer Token is not in the datastore."
+            }
+            return response, 400
+        # else, the user is in the database. Carry on.
+     
         # Get the inputted "id" from the URL path
-        # input_id = request.args.get("id")
-        # input_id = request.args['id']
-        # input_id = # get it from the the put() defintion
         input_id = request.view_args['id']
         
         # Get data from the request body

--- a/app_api_requests/package_by_id.py
+++ b/app_api_requests/package_by_id.py
@@ -17,8 +17,12 @@ class PackageById(Resource): # also why is this a POST request
         # print_to_stdout("PUT request went through")
         request.get_data() # Get everything from the request/URL (path params)
 
-        auth_header = request.headers.get('X-Authorization')
-        if auth_header is None:
+        bearer = request.headers.get('X-Authorization')
+        token = auth_header.split()[1]
+        print_to_stdout("auth_header: " + auth_header)
+        print_to_stdout("token: " + token)
+        
+        if token is None: # if token is in the database --> valid user
             return {}, 400
         # TODO: add authorization here in the future
         
@@ -42,7 +46,7 @@ class PackageById(Resource): # also why is this a POST request
             new_package_js_program = request_body['data']['JSProgram']
 
         except Exception:
-            return {}, 400
+            return {"message": "Error getting values from request body."}, 400
 
         # Check that the ID in the PATH matches the ID in the request body
         if (input_id != new_package_id):

--- a/app_api_requests/rate_package.py
+++ b/app_api_requests/rate_package.py
@@ -8,12 +8,23 @@ import json
 class RatePackage(Resource):
     def get(self, id):
         request.get_data()
-        auth_header = request.headers.get('X-Authorization')
-        if auth_header is None:
-            return {}, 400
-        # TODO: add authorization here in the future
-
+        
+        # User Authentication:
+        auth_header = request.headers.get('X-Authorization') # auth_header = "bearer [token]"
+        token = auth_header.split()[1] # token = "[token]"
+        
+        # If token is in the database --> valid user
         datastore_client = datastore.Client()
+        query = datastore_client.query(kind='user')
+        query.add_filter("bearerToken", "=", token)
+        results = list(query.fetch())
+
+        if len(results) == 0: # The token is NOT in the database --> Invalid user
+            response = {
+                'message': "Unauthorized user. Bearer Token is not in the datastore."
+            }
+            return response, 400
+        # else, the user is in the database. Carry on.
         
         package_key = datastore_client.key('package', id)
         package = datastore_client.get(package_key)

--- a/app_api_requests/reset.py
+++ b/app_api_requests/reset.py
@@ -6,13 +6,24 @@ from flask import request
 class Reset(Resource):
     def delete(self):
         request.get_data()
-        auth_header = request.headers.get('X-Authorization')
-        if auth_header is None:
-            return {}, 401
-        # TODO: add authorization here in the future
-
-
+        
+        # User Authentication:
+        auth_header = request.headers.get('X-Authorization') # auth_header = "bearer [token]"
+        token = auth_header.split()[1] # token = "[token]"
+        
+        # If token is in the database --> valid user
         datastore_client = datastore.Client()
+        query = datastore_client.query(kind='user')
+        query.add_filter("bearerToken", "=", token)
+        results = list(query.fetch())
+
+        if len(results) == 0: # The token is NOT in the database --> Invalid user
+            response = {
+                'message': "Unauthorized user. Bearer Token is not in the datastore."
+            }
+            return response, 400
+        # else, the user is in the database. Carry on.
+
         query = datastore_client.query(kind='package')
         results = list(query.fetch())
         ids = [datastore_client.key('package', x['ID']) for x in results]

--- a/main.py
+++ b/main.py
@@ -27,9 +27,10 @@ from google.cloud import datastore
 # Import your desired 
 
 from app_api_requests.create_package import CreatePackage
-from app_api_requests.package_by_id import PackageById as PackageById
+from app_api_requests.package_by_id import PackageById
 from app_api_requests.rate_package import RatePackage
 from app_api_requests.reset import Reset
+from app_api_requests.authenticate import Authenticate
 
 # Instantiates a client
 datastore_client = datastore.Client()
@@ -87,6 +88,7 @@ api.add_resource(CreatePackage, '/package', endpoint='/package')
 api.add_resource(PackageById, '/package/<string:id>')
 api.add_resource(RatePackage, '/package/<string:id>/rate', endpoint='/package_rate')
 api.add_resource(Reset, '/reset', endpoint='/reset')
+api.add_resource(Authenticate, '/authenticate')
 
 if __name__ == '__main__':
     # This is used when running locally only. When deploying to Google App


### PR DESCRIPTION
I ended up doing the "/authenticate" path, because (I think) the "/byName" path needs it as a prerequisite.
I set it up so that when we send requests for the other paths (/package and the others), that the user is authenticated before anything actually happens. 

Hopefully that makes sense. I added a **"kind = user"** in our datastore, for storing users (their name, password, bearer token, and  boolean "isAdmin").
Since we don't need top-notch protection of these passwords, I decided to pass on setting up Firestore, and use the **"kind = user" method** that I described above lol.
- So when a user provides their "X-Auth" bearer token, we just check our datastore to see if we're already storing it. 
- If we are, then we let them through. 

Also, I added Paschal's info and his bearer token to our Datastore, so that all the Postman samples are seen as a "valid user" and go through.
- https://console.cloud.google.com/datastore/entities;kind=user;ns=__$DEFAULT$__/query/kind?project=ece461-project2
-------
