### PR TITLE
New ingestion fix2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ charset-normalizer==2.0.7
 click==8.0.3
 Flask==2.0.1
 Flask-RESTful==0.3.9
+gitdb==4.0.9
+GitPython==3.1.24
 google-api-core==2.2.2
 google-auth==2.3.2
 google-cloud-core==2.2.1


### PR DESCRIPTION
So, everything works EXCEPT:
So we have the **Repo URL --> Clone it to get a file --> zip the file --> encode the zipfile into base64**.
ON THAT LAST STEP, where we have to encode it, **the encoded string is TOO LONG to be stored in datastore** ....
So hm.

When **I tested it with a small file that had ONLY a package.json it worked**.  I was able to zip the file and encode it.

But once it gets to be an **ACTUAL repo**, with MORE than just a "package.json" in the file ... then it throws this error:

![Zipfile too large](https://user-images.githubusercontent.com/51667181/144176998-49d64568-bd20-4d1d-ad64-6a4cdec76cf4.png)

**So for now ... don't test ingestion!!** Because it'll save a .zip of the repo to you curret directory --> And then you won't be able to push your branch ... because GitHub won't take a zip file that large lmao.
I LITERALLY DELETED THE .ZIP. AND THEN PUSHED. AND IT STILL WOULDN'T WORK.
I had to abandon that old branch and copy my changes omg
See:
![Screen Shot 2021-12-01 at 12 11 44 AM](https://user-images.githubusercontent.com/51667181/144177472-9b960d5a-c7cd-4cdc-acef-c35c7b64499a.png)

